### PR TITLE
fix: void `Xsession` fail when $HOME is full

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xorg (1:7.7+23-deepin1) stable; urgency=medium
+
+  * fix: void `Xsession` fail when $HOME is full
+
+ -- Chen Linxuan <me@black-desk.cn> Wed, 21 Jun 2023 10:02:06 +08000
+
 xorg (1:7.7+23-deepin) stable; urgency=medium
 
   * ['Rebuild  against by  current gcc 11.2']

--- a/debian/local/Xsession
+++ b/debian/local/Xsession
@@ -94,7 +94,9 @@ fi
 
 exec >>"$ERRFILE" 2>&1
 
-echo "$PROGNAME: X session started for $LOGNAME at $(date)"
+# This echo might fail as we just redirect stderr.
+# Just ignore that failure here.
+echo "$PROGNAME: X session started for $LOGNAME at $(date)" || true
 
 # sanity check; is our session script directory present?
 if [ ! -d "$SYSSESSIONDIR" ]; then


### PR DESCRIPTION
When user home is full,
scripts write to a file in user home will failed.

After redirect stdout and stderr to ERRFILE,
aka $HOME/.xsession-errors,
this script echo a line to that file.

This echo might failed and make this script exit with error.
In that case, the session leader will not able to even start.

Releated: linuxdeepin/developer-center#4685
Releated: linuxdeepin/dde-daemon#526
