### PR TITLE
fix: correct changelog typo

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,14 @@
+xorg (1:7.7+23-deepin2) UNRELEASED; urgency=medium
+
+  * fix: correct typo in changelog file 
+
+ -- zhoushicheng <zhoushicheng@uniontech.com>  Mon, 25 Nov 2024 15:09:23 +0800
+
 xorg (1:7.7+23-deepin1) stable; urgency=medium
 
   * fix: void `Xsession` fail when $HOME is full
 
- -- Chen Linxuan <me@black-desk.cn> Wed, 21 Jun 2023 10:02:06 +08000
+ -- Chen Linxuan <me@black-desk.cn>  Wed, 21 Jun 2023 10:02:06 +0800
 
 xorg (1:7.7+23-deepin) stable; urgency=medium
 


### PR DESCRIPTION
correct typo in changelog, time zone digits & space missing

Log: